### PR TITLE
Add (beginning of) support for Product and Product Firmware endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 sudo: false
 rvm:
   - jruby
-  - 2.0
+  - 2.3
   - 2.4

--- a/lib/particle/client.rb
+++ b/lib/particle/client.rb
@@ -1,5 +1,6 @@
 require 'particle/connection'
 require 'particle/client/devices'
+require 'particle/client/products'
 require 'particle/client/publish'
 require 'particle/client/webhooks'
 require 'particle/client/tokens'
@@ -17,6 +18,7 @@ module Particle
     include Particle::Configurable
     include Particle::Connection
     include Particle::Client::Devices
+    include Particle::Client::Products
     include Particle::Client::Publish
     include Particle::Client::Webhooks
     include Particle::Client::Tokens
@@ -51,7 +53,7 @@ module Particle
     # @param value [String] 40 character Particle OAuth2 access token
     def access_token=(value)
       reset_connection
-      @access_token = 
+      @access_token =
         if value.respond_to? :access_token
           value.access_token
         else

--- a/lib/particle/client.rb
+++ b/lib/particle/client.rb
@@ -8,6 +8,7 @@ require 'particle/client/firmware'
 require 'particle/client/build_targets'
 require 'particle/client/platforms'
 require 'particle/client/oauth_clients'
+require 'particle/client/product_firmwares'
 
 module Particle
 
@@ -26,6 +27,7 @@ module Particle
     include Particle::Client::BuildTargets
     include Particle::Client::Platforms
     include Particle::Client::OAuthClients
+    include Particle::Client::ProductFirmwares
 
     def initialize(options = {})
       # Use options passed in, but fall back to module defaults

--- a/lib/particle/client/product_firmwares.rb
+++ b/lib/particle/client/product_firmwares.rb
@@ -1,0 +1,56 @@
+require 'particle/product'
+require 'particle/product_firmware'
+
+module Particle
+  class Client
+    # Client methods for the Particle product firmware API
+    #
+    # @see https://docs.particle.io/reference/api/#product-firmware
+    module ProductFirmwares
+      # Create a domain model for a Particle product firmware object
+      #
+      # @param target [String, Hash, ProductFirmware] A product id, slug, hash of attributes or {ProductFirmware} object
+      # @return [ProductFirmware] A product object to interact with
+      def product_firmware(product, target)
+        if target.is_a? ProductFirmware
+          target
+        else
+          ProductFirmware.new(self, product, target)
+        end
+      end
+
+
+      # Create a domain model for a Particle product firmware object
+      #
+      # @param product [String, Product] A product id, slug, hash of attributes or {Product} object
+      # @param params [Hash] a hash with required attributes: (:version, :title, :binary) and optional: :description
+      # @return [ProductFirmware] A ProductFirmware object to interact with
+      def upload_product_firmware(product, params)
+        file_path = params.delete(:binary) || params.delete(:file)
+
+        params = product_firmware_file_upload_params(file_path, params)
+        res = post(product.firmware_upload_path, params)
+
+        product.firmware(res)
+      end
+
+      def product_firmware_file_upload_params(file_path, options)
+        params = {}
+        params[:binary] = Faraday::UploadIO.new(file_path, "application/octet-stream")
+        params[:file_type] = "binary"
+        params.merge! options
+        params
+      end
+
+
+      # Get information about a specific firmware version of a Particle Product
+      #
+      # @param target [ProductFirmware] A {ProductFirmware} object
+      # @return [Hash] The product attributes
+      def product_firmware_attributes(target)
+        the_product = target.product
+        get(the_product.firmware_path(target.version))
+      end
+    end
+  end
+end

--- a/lib/particle/client/products.rb
+++ b/lib/particle/client/products.rb
@@ -1,0 +1,40 @@
+require 'particle/product'
+
+module Particle
+  class Client
+    # Client methods for the Particle product API
+    #
+    # @see https://docs.particle.io/reference/api/#products
+    module Products
+      # Create a domain model for a Particle product
+      #
+      # @param target [String, Hash, Product] A product id, slug, hash of attributes or {Product} object
+      # @return [Product] A product object to interact with
+      def product(target)
+        if target.is_a? Product
+          target
+        else
+          Product.new(self, target)
+        end
+      end
+
+      # List all Particle products on the account
+      #
+      # @return [Array<Product>] List of Particle products to interact with
+      def products
+        response_body = get(Product.list_path)
+        (response_body[:products]).map { |attributes| product(attributes) }
+      end
+
+      # Get information about a Particle product
+      #
+      # @param target [String, Product] A product id, slug or {Product} object
+      # @return [Hash] The product attributes
+      def product_attributes(target)
+        response_body = get(product(target).path)
+
+        response_body[:product].first
+      end
+    end
+  end
+end

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -55,8 +55,8 @@ module Particle
       @attributes[:variables]
     end
 
-    def _product
-      @_product ||= Product.new(@client, product_id)
+    def product
+      @product ||= dev_kit? ? nil : Product.new(@client, product_id)
     end
 
     def platform
@@ -67,23 +67,8 @@ module Particle
       platform.name
     end
 
-    def product
-      return _product unless dev_kit?
-
-      puts <<~BUTT
-        DEPRECATION WARNING:
-        Using Device#product for retrieving the device's platform (i.e. 'Photon', 'Core', etc.) is deprecated; please use Device#platform_name instead (or, use Device#platform to get full platform object).
-        Behavior for Device#product will change in version 2.x.x, such that devices without a user-defined product will soon return nil.
-        (called from: #{caller(1..1).first})
-      BUTT
-
-      platform_name
-    end
-
-    # If the device isn't part of a Product that the user created
-    # (device is for prototyping), then product_id will return the platform_id.
     def dev_kit?
-      PLATFORM_IDS.include?(product_id)
+      product_id && PLATFORM_IDS.include?(product_id)
     end
 
     def get_attributes

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -1,17 +1,12 @@
 require 'particle/model'
+require 'particle/platform'
 
 module Particle
 
   # Domain model for one Particle device
   class Device < Model
     ID_REGEX = /^\h{24}$/
-    PRODUCT_IDS = {
-      0 => "Core".freeze,
-      6 => "Photon".freeze,
-      8 => "P1".freeze,
-      10 => "Electron".freeze,
-      31 => "Raspberry Pi".freeze
-    }
+    PLATFORM_IDS = Platform::IDS
 
     def initialize(client, attributes)
       super(client, attributes)
@@ -44,9 +39,11 @@ module Particle
     end
 
     attribute_reader :connected, :product_id, :last_heard, :last_app,
-      :last_ip_address
+      :last_ip_address, :platform_id, :cellular, :status, :iccid,
+      :imei, :current_build_target, :default_build_target, :system_firmware_version
 
     alias_method :connected?, :connected
+    alias_method :cellular?, :cellular
 
     def functions
       get_attributes unless @fully_loaded
@@ -58,8 +55,37 @@ module Particle
       @attributes[:variables]
     end
 
+    def _product
+      @_product ||= Product.new(@client, product_id)
+    end
+
+    def platform
+      @platform ||= Platform.new(@client, platform_id)
+    end
+
+    def platform_name
+      platform.name
+    end
+
     def product
-      PRODUCT_IDS[product_id]
+      return _product if part_of_product?
+
+      puts <<~BUTT
+        DEPRECATION WARNING:
+        Using Device#product for retrieving the device's platform (i.e. 'Photon', 'Core', etc.) is deprecated; please use Device#platform_name instead (or, use Device#platform to get full platform object).
+        Behavior for Device#product will change in version 2.x.x, such that devices without a user-defined product will soon return nil.
+        (called from: #{caller(1..1).first})
+      BUTT
+
+      platform_name
+    end
+
+    # If the device isn't part of a Product that the user created,
+    # then product_id will return the platform_id. So, conversely,
+    # if product_id is not a platform_id, then it is a part of a
+    # user-created product.
+    def part_of_product?
+      !PLATFORM_IDS.include?(product_id)
     end
 
     def get_attributes
@@ -142,7 +168,7 @@ module Particle
     # @return [OpenStruct] Result of flashing.
     #                :ok => true on success
     #                :errors => String with compile errors
-    #                
+    #
     def flash(file_paths, options = {})
       @client.flash_device(self, file_paths, options)
     end
@@ -154,7 +180,7 @@ module Particle
     # @return [OpenStruct] Result of flashing.
     #                :ok => true on success
     #                :errors => String with compile errors
-    #                
+    #
     def compile(file_paths)
       @client.compile(file_paths, device_id: id)
     end
@@ -203,4 +229,3 @@ module Particle
     end
   end
 end
-

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -68,7 +68,7 @@ module Particle
     end
 
     def product
-      return _product if part_of_product?
+      return _product unless dev_kit?
 
       puts <<~BUTT
         DEPRECATION WARNING:
@@ -80,12 +80,10 @@ module Particle
       platform_name
     end
 
-    # If the device isn't part of a Product that the user created,
-    # then product_id will return the platform_id. So, conversely,
-    # if product_id is not a platform_id, then it is a part of a
-    # user-created product.
-    def part_of_product?
-      !PLATFORM_IDS.include?(product_id)
+    # If the device isn't part of a Product that the user created
+    # (device is for prototyping), then product_id will return the platform_id.
+    def dev_kit?
+      PLATFORM_IDS.include?(product_id)
     end
 
     def get_attributes

--- a/lib/particle/model.rb
+++ b/lib/particle/model.rb
@@ -5,7 +5,7 @@ module Particle
     def initialize(client, attributes)
       @client = client
       @attributes =
-        if attributes.is_a? String
+        if attributes.is_a?(String) || attributes.is_a?(Integer)
           { id: attributes }
         else
           # Consider attributes loaded when passed in through constructor

--- a/lib/particle/platform.rb
+++ b/lib/particle/platform.rb
@@ -2,9 +2,36 @@ require 'particle/model'
 module Particle
   # Domain model for one Particle Platform from the /v1/build_targets endpoint
   class Platform < Model
+    IDS = {
+      0 => 'Core'.freeze,
+      6 => 'Photon'.freeze,
+      8 => 'P1'.freeze,
+      10 => 'Electron'.freeze,
+      31 => 'Raspberry Pi'.freeze,
+    }.freeze
+
     def initialize(client, attributes)
+      if attributes.is_a? String
+        name = attributes
+        attributes = { id: self.class.id_for_name(name), name: name }
+      end
+
+      if attributes.is_a? Integer
+        id = attributes
+        attributes = { id: id, name: self.class.name_for_id(id) }
+      end
+
       super(client, attributes)
     end
+
+    def self.id_for_name(name)
+      IDS.invert[name]
+    end
+
+    def self.name_for_id(id)
+      IDS[id]
+    end
+
     attribute_reader :name, :id
 
     # This avoids upstream magic from making .name a Symbol--keep it a string yo
@@ -13,4 +40,3 @@ module Particle
     end
   end
 end
-

--- a/lib/particle/product.rb
+++ b/lib/particle/product.rb
@@ -1,0 +1,60 @@
+require 'particle/model'
+
+module Particle
+
+  # Domain model for one Particle device
+  class Product < Model
+    ID_REGEX = /^\d{1,5}$/
+
+    def initialize(client, attributes)
+      super(client, attributes)
+
+      attributes = attributes.to_s if attributes.is_a?(Integer)
+
+      if attributes.is_a? String
+        if attributes =~ ID_REGEX
+          @attributes = { id: attributes }
+        else
+          @attributes = { slug: attributes }
+        end
+      else
+        # Listing all devices returns partial attributes so check if the
+        # device was fully loaded or not
+        @fully_loaded = true if attributes.key?(:name)
+      end
+    end
+
+    # NOTE: the key :requires_activation_codes is documented (as of 2018/05/19)
+    # but does not seem to come through in the response for product requests,
+    # so excluding it for now.
+    attribute_reader :name, :description, :platform_id, :type, :hardware_version,
+      :config_id, :organization
+
+    def get_attributes
+      @loaded = @fully_loaded = true
+      @attributes = @client.product_attributes(self)
+    end
+
+    def id
+      get_attributes unless @attributes[:id]
+      @attributes[:id]
+    end
+
+    def slug
+      get_attributes unless @attributes[:slug]
+      @attributes[:slug]
+    end
+
+    def id_or_slug
+      @attributes[:id] || @attributes[:slug]
+    end
+
+    def self.list_path
+      "v1/products"
+    end
+
+    def path
+      "/v1/products/#{id_or_slug}"
+    end
+  end
+end

--- a/lib/particle/product.rb
+++ b/lib/particle/product.rb
@@ -2,9 +2,9 @@ require 'particle/model'
 
 module Particle
 
-  # Domain model for one Particle device
+  # Domain model for one Particle product
   class Product < Model
-    ID_REGEX = /^\d{1,5}$/
+    ID_REGEX = /^\d+$/
 
     def initialize(client, attributes)
       super(client, attributes)
@@ -24,9 +24,6 @@ module Particle
       end
     end
 
-    # NOTE: the key :requires_activation_codes is documented (as of 2018/05/19)
-    # but does not seem to come through in the response for product requests,
-    # so excluding it for now.
     attribute_reader :name, :description, :platform_id, :type, :hardware_version,
       :config_id, :organization
 

--- a/lib/particle/product.rb
+++ b/lib/particle/product.rb
@@ -35,6 +35,15 @@ module Particle
       @attributes = @client.product_attributes(self)
     end
 
+    def firmware(target)
+      @client.product_firmware(self, target)
+    end
+
+    def upload_firmware(version, title, binary, desc = nil)
+      params = { version: version, title: title, binary: binary, description: desc }
+      @client.upload_product_firmware(self, params)
+    end
+
     def id
       get_attributes unless @attributes[:id]
       @attributes[:id]
@@ -55,6 +64,14 @@ module Particle
 
     def path
       "/v1/products/#{id_or_slug}"
+    end
+
+    def firmware_path(version)
+      "/v1/products/#{id_or_slug}/firmware/#{version}"
+    end
+
+    def firmware_upload_path
+      "/v1/products/#{id_or_slug}/firmware"
     end
   end
 end

--- a/lib/particle/product_firmware.rb
+++ b/lib/particle/product_firmware.rb
@@ -1,0 +1,56 @@
+require 'particle/model'
+require 'particle/product'
+
+module Particle
+  # Domain model for one Particle device
+  class ProductFirmware < Model
+    ID_REGEX = /^\d{1,6}$/
+
+    def initialize(client, product_or_id, attributes)
+      super(client, attributes)
+
+      product = client.product(product_or_id)
+
+      @attributes = { version: attributes } if attributes.is_a?(Integer) || attributes.is_a?(String)
+      @attributes = @attributes.merge(product: product, product_id: product.id)
+
+      @fully_loaded = true if @attributes.key?(:title)
+    end
+
+    def get_attributes
+      @loaded = @fully_loaded = true
+      @attributes = @client.product_firmware_attributes(self)
+    end
+
+    def version
+      get_attributes unless @attributes[:version]
+      @attributes[:version]
+    end
+
+    def title
+      get_attributes unless @attributes[:title]
+      @attributes[:title]
+    end
+
+    def description
+      get_attributes unless @attributes[:description]
+      @attributes[:description]
+    end
+
+    def product
+      @attributes[:product]
+    end
+
+    def product_id
+      product.id
+    end
+
+    def path
+      "/v1/products/#{product_id}/firmware/#{version}"
+    end
+
+    def upload_path
+      "/v1/products/#{product_id}/firmware"
+    end
+  end
+end

--- a/spec/cassettes/Particle_Client_Products/_product_attributes/returns_attributes.json
+++ b/spec/cassettes/Particle_Client_Products/_product_attributes/returns_attributes.json
@@ -1,0 +1,64 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Sat, 19 May 2018 18:56:54 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "318"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "9c4cd3c1-2b0a-4a6a-a1ac-8b6837ebb179"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"product\":[{\"id\":__PARTICLE_PRODUCT_ID_0__,\"platform_id\":10,\"name\":\"product_name\",\"slug\":\"product_slug\",\"latest_firmware_version\":null,\"description\":\"Product Description\",\"type\":null,\"hardware_version\":\"v1.0.0\",\"config_id\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"organization\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"subscription_id\":99999,\"mb_limit\":null,\"groups\":[]}]}"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Sat, 19 May 2018 18:56:54 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_Client_Products/_product_attributes/when_product_doesn_t_exist/raises_NotFound.json
+++ b/spec/cassettes/Particle_Client_Products/_product_attributes/when_product_doesn_t_exist/raises_NotFound.json
@@ -1,0 +1,64 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/123456",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "headers": {
+          "Date": [
+            "Sat, 19 May 2018 19:01:43 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "41"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "f1e50915-ee06-4cb6-afdf-67830447a238"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"ok\":false,\"error\":\"Product not found.\"}"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Sat, 19 May 2018 19:01:43 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_Client_Products/_products/returns_all_Particle_products.json
+++ b/spec/cassettes/Particle_Client_Products/_products/returns_all_Particle_products.json
@@ -1,0 +1,64 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Sat, 19 May 2018 19:03:49 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "767d8199-06fa-4487-93ff-d7169bc0bc77"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJwcm9kdWN0cyI6W3siaWQiOjEyMywicGxhdGZvcm1faWQiOjYsIm5hbWUi\nOiJQcm9kdWN0IDEiLCJzbHVnIjoicHJvZHVjdDEiLCJsYXRlc3RfZmlybXdh\ncmVfdmVyc2lvbiI6bnVsbCwiZGVzY3JpcHRpb24iOiJUaGUgY29vbGVzdCBw\ncm9kdWN0IGZvciB0aGUgY29vbGVzdCBraWRzIGluIHRvd24uIiwidHlwZSI6\nIkNvbnN1bWVyIiwiaGFyZHdhcmVfdmVyc2lvbiI6InYxLjAuMCIsImNvbmZp\nZ19pZCI6IjExMTExMTExMTExMTExMTExMTExMTExMSIsIm9yZ2FuaXphdGlv\nbiI6IjExMTExMTExMTExMTExMTExMTExMTExMSIsInJlcXVpcmVzX2FjdGl2\nYXRpb25fY29kZXMiOmZhbHNlLCJzdWJzY3JpcHRpb25faWQiOjExMTEsIm1i\nX2xpbWl0IjpudWxsLCJncm91cHMiOltdfSx7ImlkIjoyMzQsInBsYXRmb3Jt\nX2lkIjoxMCwibmFtZSI6IlByb2R1Y3QgMiIsInNsdWciOiJwcm9kdWN0MiIs\nImxhdGVzdF9maXJtd2FyZV92ZXJzaW9uIjpudWxsLCJkZXNjcmlwdGlvbiI6\nIkFsc28gbm90IGEgYmFkIHByb2R1Y3QuIiwidHlwZSI6IkNvbnN1bWVyIiwi\naGFyZHdhcmVfdmVyc2lvbiI6InYwLjEuMCIsImNvbmZpZ19pZCI6IjExMTEx\nMTExMTExMTExMTExMTExMTExMSIsIm9yZ2FuaXphdGlvbiI6IjExMTExMTEx\nMTExMTExMTExMTExMTExMSIsInJlcXVpcmVzX2FjdGl2YXRpb25fY29kZXMi\nOnRydWUsInN1YnNjcmlwdGlvbl9pZCI6MTExMSwibWJfbGltaXQiOm51bGws\nImdyb3VwcyI6W119XX0=\n"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Sat, 19 May 2018 19:03:49 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_Device/_attributes/includes_details_like_functions_and_platform.json
+++ b/spec/cassettes/Particle_Device/_attributes/includes_details_like_functions_and_platform.json
@@ -10,7 +10,7 @@
         },
         "headers": {
           "User-Agent": [
-            "particlerb Ruby gem 0.0.4"
+            "particlerb Ruby gem 1.4.0"
           ],
           "Authorization": [
             "Bearer __PARTICLE_ACCESS_TOKEN__"
@@ -29,38 +29,35 @@
           "message": "OK"
         },
         "headers": {
-          "Server": [
-            "nginx/1.6.2"
-          ],
           "Date": [
-            "Wed, 15 Jul 2015 13:46:54 GMT"
+            "Sat, 19 May 2018 18:01:23 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "312"
+            "610"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "X-Powered-By": [
-            "Express"
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
           ],
           "Access-Control-Allow-Origin": [
             "*"
-          ],
-          "Etag": [
-            "W/\"138-f6d0ae46\""
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "string": "{\n  \"id\": \"__PARTICLE_DEVICE_ID_0__\",\n  \"name\": \"fried\",\n  \"connected\": true,\n  \"variables\": {\n    \"answer\": \"int32\"\n  },\n  \"functions\": [\n    \"toggle\"\n  ],\n  \"cc3000_patch_version\": \"wl0: Nov  7 2014 16:03:45 version 5.90.230.12 FWID 01-d4813443\",\n  \"product_id\": 6,\n  \"last_heard\": \"2015-07-15T13:46:53.473Z\"\n}"
+          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-03-28T03:08:10.380Z\",\"product_id\":10,\"connected\":false,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"]}"
         },
         "http_version": null
       },
-      "recorded_at": "Wed, 15 Jul 2015 13:46:54 GMT"
+      "recorded_at": "Sat, 19 May 2018 18:01:21 GMT"
     }
   ],
   "recorded_with": "VCR 2.9.3"

--- a/spec/cassettes/Particle_Device/_product/device_is_not_part_of_user_defined_product/returns_nil.json
+++ b/spec/cassettes/Particle_Device/_product/device_is_not_part_of_user_defined_product/returns_nil.json
@@ -30,13 +30,13 @@
         },
         "headers": {
           "Date": [
-            "Sat, 19 May 2018 18:01:23 GMT"
+            "Sat, 19 May 2018 18:03:11 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "610"
+            "716"
           ],
           "Connection": [
             "keep-alive"
@@ -53,11 +53,11 @@
         },
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-03-28T03:08:10.380Z\",\"product_id\":10,\"connected\":false,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"]}"
+          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-05-16T09:17:12.266Z\",\"product_id\":10,\"connected\":true,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"serial_number\":\"A123-123456-AB12-1\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"],\"groups\":[],\"targeted_firmware_release_version\":null}"
         },
         "http_version": null
       },
-      "recorded_at": "Sat, 19 May 2018 18:01:21 GMT"
+      "recorded_at": "Sat, 19 May 2018 18:03:08 GMT"
     }
   ],
   "recorded_with": "VCR 2.9.3"

--- a/spec/cassettes/Particle_Device/_product/device_is_not_part_of_user_defined_product/sets_the_product_string.json
+++ b/spec/cassettes/Particle_Device/_product/device_is_not_part_of_user_defined_product/sets_the_product_string.json
@@ -10,7 +10,7 @@
         },
         "headers": {
           "User-Agent": [
-            "particlerb Ruby gem 0.0.4"
+            "particlerb Ruby gem 1.4.0"
           ],
           "Authorization": [
             "Bearer __PARTICLE_ACCESS_TOKEN__"
@@ -29,38 +29,35 @@
           "message": "OK"
         },
         "headers": {
-          "Server": [
-            "nginx/1.6.2"
-          ],
           "Date": [
-            "Wed, 15 Jul 2015 13:46:54 GMT"
+            "Sat, 19 May 2018 18:01:23 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "312"
+            "610"
           ],
           "Connection": [
             "keep-alive"
           ],
-          "X-Powered-By": [
-            "Express"
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
           ],
           "Access-Control-Allow-Origin": [
             "*"
-          ],
-          "Etag": [
-            "W/\"138-f6d0ae46\""
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "string": "{\n  \"id\": \"__PARTICLE_DEVICE_ID_0__\",\n  \"name\": \"fried\",\n  \"connected\": true,\n  \"variables\": {\n    \"answer\": \"int32\"\n  },\n  \"functions\": [\n    \"toggle\"\n  ],\n  \"cc3000_patch_version\": \"wl0: Nov  7 2014 16:03:45 version 5.90.230.12 FWID 01-d4813443\",\n  \"product_id\": 6,\n  \"last_heard\": \"2015-07-15T13:46:53.473Z\"\n}"
+          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-03-28T03:08:10.380Z\",\"product_id\":10,\"connected\":false,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"]}"
         },
         "http_version": null
       },
-      "recorded_at": "Wed, 15 Jul 2015 13:46:54 GMT"
+      "recorded_at": "Sat, 19 May 2018 18:01:21 GMT"
     }
   ],
   "recorded_with": "VCR 2.9.3"

--- a/spec/cassettes/Particle_Device/_product/device_is_part_of_user_defined_product/returns_a_Product_instance.json
+++ b/spec/cassettes/Particle_Device/_product/device_is_part_of_user_defined_product/returns_a_Product_instance.json
@@ -30,13 +30,13 @@
         },
         "headers": {
           "Date": [
-            "Sat, 19 May 2018 18:01:23 GMT"
+            "Sat, 19 May 2018 18:03:11 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "610"
+            "716"
           ],
           "Connection": [
             "keep-alive"
@@ -53,11 +53,11 @@
         },
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-03-28T03:08:10.380Z\",\"product_id\":10,\"connected\":false,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"]}"
+          "string": "{\"id\":\"__PARTICLE_DEVICE_ID_0__\",\"name\":\"mydevice\",\"last_app\":null,\"last_ip_address\":\"00.00.000.000\",\"last_heard\":\"2018-05-16T09:17:12.266Z\",\"product_id\":1234,\"connected\":true,\"platform_id\":10,\"cellular\":true,\"notes\":null,\"status\":\"normal\",\"serial_number\":\"A123-123456-AB12-1\",\"iccid\":\"1111111111111111111\",\"last_iccid\":\"1111111111111111111\",\"imei\":\"111111111111111\",\"current_build_target\":\"0.6.4\",\"system_firmware_version\":\"0.6.4\",\"default_build_target\":\"0.6.4\",\"variables\":{},\"functions\":[\"reset\"],\"groups\":[],\"targeted_firmware_release_version\":null}"
         },
         "http_version": null
       },
-      "recorded_at": "Sat, 19 May 2018 18:01:21 GMT"
+      "recorded_at": "Sat, 19 May 2018 18:03:08 GMT"
     }
   ],
   "recorded_with": "VCR 2.9.3"

--- a/spec/cassettes/Particle_Product/_attributes/returns_attributes.json
+++ b/spec/cassettes/Particle_Product/_attributes/returns_attributes.json
@@ -1,0 +1,64 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Wed, 09 May 2018 20:11:10 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "318"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"product\":[{\"id\":__PARTICLE_PRODUCT_ID_0__,\"platform_id\":10,\"name\":\"product_name\",\"slug\":\"product_slug\",\"latest_firmware_version\":null,\"description\":\"Product Description\",\"type\":null,\"hardware_version\":\"v1.0.0\",\"config_id\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"organization\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"subscription_id\":99999,\"mb_limit\":null,\"groups\":[]}]}"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Wed, 09 May 2018 20:11:10 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_ProductFirmware/_attributes/returns_attributes.json
+++ b/spec/cassettes/Particle_ProductFirmware/_attributes/returns_attributes.json
@@ -1,0 +1,64 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__/firmware/1",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Wed, 09 May 2018 23:37:39 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "868"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"updated_at\":\"2018-04-06T12:45:32.755Z\",\"uploaded_on\":\"2018-04-06T12:45:32.755Z\",\"uploaded_by\":{},\"version\":1,\"product_id\":__PARTICLE_PRODUCT_ID_0__,\"size\":37432,\"name\":\"particle_fw.bin\",\"title\":\"First FW Upload\",\"description\":\"upload description\",\"_id\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"current\":false,\"product_default\":false,\"groups\":[]}"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Wed, 09 May 2018 23:37:39 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_ProductFirmware/_upload_firmware/uploads_and_returns_a_firmware_object.json
+++ b/spec/cassettes/Particle_ProductFirmware/_upload_firmware/uploads_and_returns_a_firmware_object.json
@@ -1,0 +1,70 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__/firmware",
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string":"ACTUAL_BINARY"
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 1.4.0"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Content-Type": [
+            "multipart/form-data; boundary=-----------RubyMultipartPost"
+          ],
+          "Content-Length": [
+            "39917"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Date": [
+            "Thu, 10 May 2018 00:07:27 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "642"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx"
+          ],
+          "X-Request-Id": [
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"updated_at\":\"2018-05-10T00:07:27.655Z\",\"uploaded_on\":\"2018-05-10T00:07:27.655Z\",\"uploaded_by\":{},\"version\":3,\"product_id\":__PARTICLE_PRODUCT_ID_0__,\"size\":39292,\"name\":\"spark_tinker.bin\",\"title\":\"Test Firmware Upload\",\"description\":\"upload description\",\"_id\":\"aaaaaaaaaaaaaaaaaaaaaaaa\",\"current\":false,\"product_default\":false,\"groups\":[]}"
+        },
+        "http_version": null
+      },
+      "recorded_at": "Thu, 10 May 2018 00:07:27 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -57,6 +57,18 @@ def test_particle_oauth_secret
   ENV.fetch('TEST_PARTICLE_OAUTH_SECRET', 'my_oauth_secret')
 end
 
+def test_particle_product_firmware_version
+  ENV.fetch('TEST_PARTICLE_PRODUCT_FIRMWARE_VERSION', '1')
+end
+
+def test_product_firmware_binary
+  ENV.fetch('TEST_PARTICLE_PRODUCT_FIRMWARE_BINARY', 'spec/fixtures/spark_tinker.bin')
+end
+
+def product_firmware_version
+  test_particle_product_firmware_version
+end
+
 VCR.configure do |c|
   c.configure_rspec_metadata!
   c.filter_sensitive_data("__PARTICLE_USERNAME__") do
@@ -93,6 +105,10 @@ VCR.configure do |c|
   }
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
+
+  c.preserve_exact_body_bytes do |http_message|
+    http_message.body.encoding.name == 'ASCII-8BIT' || !http_message.body.valid_encoding?
+  end
 
   # Monkey-patch cassette serializer to pretty print JSON
   module VCR::Cassette::Serializers::JSON

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,8 +14,8 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     if example.metadata[:vcr]
       Particle.reset!
-      Particle.configure do |config|
-        config.access_token = test_particle_access_token
+      Particle.configure do |particle_config|
+        particle_config.access_token = test_particle_access_token
       end
     end
   end
@@ -39,6 +39,14 @@ end
 
 def test_particle_device_ids
   ENV.fetch('TEST_PARTICLE_DEVICE_IDS', 'a' * 24).split(",")
+end
+
+def product_id
+  test_particle_product_ids[0]
+end
+
+def test_particle_product_ids
+  ENV.fetch('TEST_PARTICLE_PRODUCT_IDS', '2' * 4).split(",")
 end
 
 def test_particle_oauth_client
@@ -66,6 +74,10 @@ VCR.configure do |c|
   end
   test_particle_device_ids.each_with_index do |device_id, index|
     c.filter_sensitive_data("__PARTICLE_DEVICE_ID_#{index}__") { device_id }
+  end
+
+  test_particle_product_ids.each_with_index do |product_id, index|
+    c.filter_sensitive_data("__PARTICLE_PRODUCT_ID_#{index}__") { product_id }
   end
 
   c.filter_sensitive_data("__PARTICLE_OAUTH_CLIENT__") do

--- a/spec/particle/client/build_targets_spec.rb
+++ b/spec/particle/client/build_targets_spec.rb
@@ -7,7 +7,7 @@ describe Particle::Client::BuildTargets, :vcr do
       build_targets = Particle.build_targets
       expect(build_targets).to be_kind_of Array
       build_targets.each { |d| expect(d).to be_kind_of Particle::BuildTarget}
-      expect(build_targets.length).to be >= Particle::Device::PRODUCT_IDS.keys.length, "there should be at least 1 build target for each hardware platform"
+      expect(build_targets.length).to be >= Particle::Device::PLATFORM_IDS.keys.length, "there should be at least 1 build target for each hardware platform"
     end
   end
 end

--- a/spec/particle/client/products_spec.rb
+++ b/spec/particle/client/products_spec.rb
@@ -1,0 +1,31 @@
+require 'helper'
+
+describe Particle::Client::Products, :vcr do
+  describe '.products' do
+    it 'returns all Particle products' do
+      products = Particle.products
+      expect(products).to be_kind_of Array
+      products.each { |prod| expect(prod).to be_kind_of Particle::Product }
+    end
+  end
+
+  describe '.product_attributes' do
+    it 'returns attributes' do
+      attr = Particle.product_attributes(product_id)
+
+      expect(attr.keys).to include(
+        :id, :name, :description, :platform_id, :type, :hardware_version,
+        :config_id, :organization
+      )
+
+      expect(attr[:id]).to eq product_id.to_i
+    end
+
+    context "when product doesn't exist" do
+      it 'raises NotFound' do
+        expect { Particle.product_attributes('123456') }.
+          to raise_error(Particle::NotFound)
+      end
+    end
+  end
+end

--- a/spec/particle/device_spec.rb
+++ b/spec/particle/device_spec.rb
@@ -14,12 +14,23 @@ describe Particle::Device do
       expect(device.attributes).to be_kind_of Hash
     end
 
-    it "includes details like functions" do
+    it "includes details like functions and platform" do
       expect(device.functions).to be_kind_of Array
+      expect(device.platform).to be_kind_of Particle::Platform
+    end
+  end
+
+  describe '.product', :vcr do
+    context 'device is part of user defined product' do
+      it 'returns a Product instance' do
+        expect(device.product).to be_kind_of Particle::Product
+      end
     end
 
-    it "sets the product string" do
-      expect(["Core", "Photon"]).to include(device.product)
+    context 'device is not part of user defined product' do
+      it 'sets the product string' do
+        expect(%w[Core Photon Electron]).to include(device.product)
+      end
     end
   end
 
@@ -104,4 +115,3 @@ describe Particle::Device do
     end
   end
 end
-

--- a/spec/particle/device_spec.rb
+++ b/spec/particle/device_spec.rb
@@ -28,8 +28,8 @@ describe Particle::Device do
     end
 
     context 'device is not part of user defined product' do
-      it 'sets the product string' do
-        expect(%w[Core Photon Electron]).to include(device.product)
+      it 'returns nil' do
+        expect(device.product).to be_nil
       end
     end
   end

--- a/spec/particle/platform_spec.rb
+++ b/spec/particle/platform_spec.rb
@@ -3,9 +3,29 @@ require 'helper'
 describe Particle::Platform do
   let(:name) { "Photon" }
   let(:platform_id) { 6 }
-  let(:platform) { Particle.platform(name: name, id: platform_id) }
-  it "has accessors" do
-    expect(platform.name).to eql(name)
-    expect(platform.id).to eql(platform_id)
+
+  shared_examples "has_accessors" do
+    it "has accessors" do
+      expect(platform.name).to eql(name)
+      expect(platform.id).to eql(platform_id)
+    end
+  end
+
+  describe "when instantiated with attributes" do
+    let(:platform) { Particle.platform(name: name, id: platform_id) }
+
+    it_behaves_like "has_accessors"
+  end
+
+  describe "when instantiated by name" do
+    let(:platform) { Particle.platform(name) }
+
+    it_behaves_like "has_accessors"
+  end
+
+  describe "when instantiated by id" do
+    let(:platform) { Particle.platform(platform_id) }
+
+    it_behaves_like "has_accessors"
   end
 end

--- a/spec/particle/product_firmware_spec.rb
+++ b/spec/particle/product_firmware_spec.rb
@@ -1,0 +1,35 @@
+require 'helper'
+
+describe Particle::ProductFirmware do
+  let(:product) { Particle.product(product_id) }
+  let(:product_firmware) { Particle.product_firmware(product, product_firmware_version) }
+
+  describe "Particle.product_firmware" do
+    it "creates a product firmware object" do
+      expect(product_firmware.version).to eq(product_firmware_version)
+    end
+  end
+
+  describe ".attributes", :vcr do
+    it "returns attributes" do
+      expect(product_firmware.attributes).to be_kind_of Hash
+      expect(product_firmware.title).to be_kind_of String
+    end
+  end
+
+  describe ".upload_firmware", :vcr do
+    let(:new_version) { 3 }
+    let(:title) { 'Test Firmware Upload' }
+    let(:description) { 'upload description' }
+
+    let(:binary) { test_product_firmware_binary }
+
+    it "uploads and returns a firmware object" do
+      product_firmware = product.upload_firmware(new_version, title, binary, description)
+
+      expect(product_firmware.version).to eq(new_version)
+      expect(product_firmware.title).to eq(title)
+      expect(product_firmware.description).to eq(description)
+    end
+  end
+end

--- a/spec/particle/product_spec.rb
+++ b/spec/particle/product_spec.rb
@@ -1,0 +1,18 @@
+require 'helper'
+
+describe Particle::Product do
+  let(:product) { Particle.product(product_id) }
+
+  describe "Particle.product" do
+    it "creates a product" do
+      expect(Particle.product("abc").slug).to eq("abc")
+    end
+  end
+
+  describe ".attributes", :vcr do
+    it "returns attributes" do
+      expect(product.name).to be_kind_of String
+      expect(product.attributes).to be_kind_of Hash
+    end
+  end
+end


### PR DESCRIPTION
#### What/Why
I had a use-case for finding a device's product and then uploading firmware for that product. I saw that this wasn't yet implemented, so I added some classes/methods/tests to support this.

#### There are notes in each commit, but to summarize:
* `Particle.products` returns all products for the client
* `Device#product` now returns *either*:
  * The device's product (IF the device belongs to a user-created product)
  * The device's platform name (i.e. 'Photon'; IF the device does not belong to a user-created product)
    * This second case includes a deprecation warning, but is an attempt to preserve the old behavior so as not to introduce a breaking change (see NOTE on this below)
* `Product#firmware(target)` returns firmware for the given version (or attributes)
* `Product#upload_firmware` allows uploading of firmware, and returns `ProductFirmware` object if successful

#### Endpoints supported:
+ List Products (GET `/v1/products`)
+ Product Details (GET `/v1/products/:id`)
+ Upload firmware (POST `/v1/products/:productId/firmware`)
+ Get firmware details (GET `/v1/products/:productId/firmware/:version`)

#### NOTE from above (re: product/platform)
My opinion is that the correct eventual strategy for this is that `Device#product` returns a `Particle::Product` object no matter what. It seems like the API behaves in the following way:

* In the case that the device doesn't belong to a user-defined Product, the `product_id` of the device refers to the `platform_id`, and (somewhat confusingly) things like Photons and Electrons also return products (like the photon response in https://docs.particle.io/reference/api/#retrieve-a-product).

...Thus, I think the simplest and most correct solution would be to simply have `Device#product` return a `Particle::Product` all the time, and sometimes this is the "photon" type (or particle-defined product), and sometimes it's user-defined. Then, `Device#platform` returns a `Particle::Platform` object and `Device#platform_name` can be a quick way to get something like "Photon" or "Electron".

However, since right now (1.4.0) this would break any code that relies on `Device#product` returning a string like "Photon", I did it this way with the thought that it can be like 1.5.0, and give users some warning about changing their code. However, if the you (the maintainers) feel like we could just jump versions and introduce the breaking change, that totally works for me too and I can recommit.

Let me know if you have questions or see things I should change. Thanks!
