### PR TITLE
Farady version bump

### DIFF
--- a/particlerb.gemspec
+++ b/particlerb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
   spec.required_rubygems_version = '>= 1.3.5'
   spec.version = Particle::VERSION.dup
-  spec.add_dependency 'faraday', '~> 0.9.0'
+  spec.add_dependency 'faraday', '>= 0.9.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Faraday old version was being used causing dependency issues. This solved our issues, might help others as well.