### PR TITLE
Update Products and Product classes to support new Particle API

### DIFF
--- a/lib/particle/client/products.rb
+++ b/lib/particle/client/products.rb
@@ -33,7 +33,11 @@ module Particle
       def product_attributes(target)
         response_body = get(product(target).path)
 
-        response_body[:product].first
+        # originally returned as an array, now seems to just return the 1 product as a hash;
+        # this will handle both cases
+        product = response_body[:product]
+        product = product.first if product.is_a?(Array)
+        product
       end
     end
   end

--- a/lib/particle/product.rb
+++ b/lib/particle/product.rb
@@ -25,7 +25,9 @@ module Particle
     end
 
     attribute_reader :name, :description, :platform_id, :type, :hardware_version,
-      :config_id, :organization
+      :config_id,
+      # below here are new attributes that appeared with API change
+      :subscription_id, :mb_limit, :groups, :settings, :org
 
     def get_attributes
       @loaded = @fully_loaded = true
@@ -49,6 +51,11 @@ module Particle
     def slug
       get_attributes unless @attributes[:slug]
       @attributes[:slug]
+    end
+
+    def organization
+      get_attributes unless @attributes[:organization] || @attributes[:org]
+      @attributes[:organization] || @attributes[:org]
     end
 
     def id_or_slug

--- a/spec/cassettes/Particle_Client_Products/_product_attributes/when_Particle_updates_API_without_version_bump/returns_attributes.json
+++ b/spec/cassettes/Particle_Client_Products/_product_attributes/when_Particle_updates_API_without_version_bump/returns_attributes.json
@@ -1,0 +1,70 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 2.0.1"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Tue, 30 Jul 2019 03:56:47 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx/1.15.10"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Request-Id": [
+            "babe352383de30feb5205f67a865f7cb"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "X-Requested-Scope": [
+            "product___PARTICLE_PRODUCT_ID_0__:product:get"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJwcm9kdWN0Ijp7ImlkIjpfX1BBUlRJQ0xFX1BST0RVQ1RfSURfMF9fLCJwbGF0Zm9ybV9pZCI6MTAsIm5hbWUiOiJwcm9kdWN0Iiwic2x1ZyI6Im15cHJvZHVjdCIsImRlc2NyaXB0aW9uIjoiR3JlYXQgcHJvZHVjdC4iLCJzdWJzY3JpcHRpb25faWQiOjExMTExLCJtYl9saW1pdCI6bnVsbCwiZ3JvdXBzIjpbXSwic2V0dGluZ3MiOnsicXVhcmFudGluZSI6dHJ1ZX0sIm9yZyI6Im15cHJvZHVjdCJ9fQ=="
+        },
+        "http_version": null
+      },
+      "recorded_at": "Tue, 30 Jul 2019 03:56:47 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/cassettes/Particle_Product/_attributes/when_Particle_surpises_us_with_an_awesome_new_API/returns_attributes.json
+++ b/spec/cassettes/Particle_Product/_attributes/when_Particle_surpises_us_with_an_awesome_new_API/returns_attributes.json
@@ -1,0 +1,70 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.particle.io/v1/products/__PARTICLE_PRODUCT_ID_0__",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "User-Agent": [
+            "particlerb Ruby gem 2.0.1"
+          ],
+          "Authorization": [
+            "Bearer __PARTICLE_ACCESS_TOKEN__"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Date": [
+            "Tue, 30 Jul 2019 04:09:55 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Server": [
+            "nginx/1.15.10"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Request-Id": [
+            "557fe9e11733649ea6766f6cbc6549fd"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "X-Requested-Scope": [
+            "product___PARTICLE_PRODUCT_ID_0__:product:get"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJwcm9kdWN0Ijp7ImlkIjpfX1BBUlRJQ0xFX1BST0RVQ1RfSURfMF9fLCJwbGF0Zm9ybV9pZCI6MTAsIm5hbWUiOiJwcm9kdWN0Iiwic2x1ZyI6Im15cHJvZHVjdCIsImRlc2NyaXB0aW9uIjoiR3JlYXQgcHJvZHVjdC4iLCJzdWJzY3JpcHRpb25faWQiOjExMTExLCJtYl9saW1pdCI6bnVsbCwiZ3JvdXBzIjpbXSwic2V0dGluZ3MiOnsicXVhcmFudGluZSI6dHJ1ZX0sIm9yZyI6Im15cHJvZHVjdCJ9fQ=="
+        },
+        "http_version": null
+      },
+      "recorded_at": "Tue, 30 Jul 2019 04:09:55 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/particle/client/products_spec.rb
+++ b/spec/particle/client/products_spec.rb
@@ -27,5 +27,18 @@ describe Particle::Client::Products, :vcr do
           to raise_error(Particle::NotFound)
       end
     end
+
+    context 'when Particle updates API without version bump' do
+      it 'returns attributes' do
+        attr = Particle.product_attributes(product_id)
+
+        expect(attr.keys).to include(
+          :id, :platform_id, :name, :slug, :description,
+          :subscription_id, :mb_limit, :groups, :settings, :org,
+        )
+
+        expect(attr[:id]).to eq product_id.to_i
+      end
+    end
   end
 end

--- a/spec/particle/product_spec.rb
+++ b/spec/particle/product_spec.rb
@@ -13,6 +13,15 @@ describe Particle::Product do
     it "returns attributes" do
       expect(product.name).to be_kind_of String
       expect(product.attributes).to be_kind_of Hash
+      expect(product.organization).to be_kind_of String
+    end
+
+    context 'when Particle surpises us with an awesome new API' do
+      it 'returns attributes' do
+        expect(product.name).to be_kind_of String
+        expect(product.attributes).to be_kind_of Hash
+        expect(product.organization).to be_kind_of String
+      end
     end
   end
 end


### PR DESCRIPTION
### The Issue
Particle seems to have changed their API out of the blue, without updating the docs, and (more importantly) without version bump. This breaks the current `particlerb` client when trying to get product detail, with this kind of error:

```
/<stuff>/vendor/bundler/gems/particlerb-2.0.0/lib/particle/model.rb:33:in `[]': no implicit conversion of Symbol into Integer (TypeError)
```

There are some details in the issue I opened on the forum here: https://community.particle.io/t/cloud-api-breaking-changes-without-version-bump/51449

I'm not sure exactly which version this library should be aiming to support, since the Particle Cloud API doesn't seem to be in sync right now; I guess we should update this one way or the other once there is some more clarity from Particle. For now, I tried to make it as inclusive as possible so that it works as well as possible for both "versions" of (the same version of) the endpoint.

### The Fix
This now (*mostly*, see below) supports both versions of the api (the "old" `v1/products/:id` endpoint that is what the docs say, and the "new" `v1/products/:id` endpoint that is actually returned). Specifically, it handles the `$.product` key being returned as an array OR a hash, and also supports the new methods/attributes via `attribute_reader`.

I also backwards-compatibled the `organization` method (because that maps to the `org` attribute in new version of the API).

I think the only things that will still break are trying to access the `type` and `hardware_version` attributes of a Product (can't remember if this will error, or if the behavior is to return `nil`). But, on the other hand, I didn't want to remove those attributes/methods, because I don't know what the future will look like for this endpoint (maybe it will be reverted, or they will be added back).